### PR TITLE
Rewrite from List::MoreUtils to List::Util

### DIFF
--- a/generate-p2v-config.pl
+++ b/generate-p2v-config.pl
@@ -19,7 +19,7 @@ use warnings;
 
 use Class::Struct;
 use Getopt::Long;
-use List::MoreUtils qw(any);
+use List::Util 1.33 qw(any);
 
 struct ConfigSection =>
 {

--- a/m4/p2v-progs.m4
+++ b/m4/p2v-progs.m4
@@ -57,10 +57,10 @@ else
     AC_MSG_RESULT([yes])
 fi
 
-dnl Check for List::MoreUtils, used by generate-p2v-config.pl
-AC_MSG_CHECKING([for List::MoreUtils])
-if ! $PERL -MList::MoreUtils -e1 >&AS_MESSAGE_LOG_FD 2>&1; then
-    AC_MSG_ERROR([perl List::MoreUtils must be installed])
+dnl Check for List::Util, used by generate-p2v-config.pl
+AC_MSG_CHECKING([for List::Util])
+if ! $PERL -MList::Util=1.33 -e1 >&AS_MESSAGE_LOG_FD 2>&1; then
+    AC_MSG_ERROR([perl List::Util@1.33 must be installed])
 else
     AC_MSG_RESULT([yes])
 fi


### PR DESCRIPTION
List::Util is much updated than List::MoreUtils, has c implementation, is in Perl Core. Function any() was added in 1.33 version.

Check $PERL -MList::Util=1.33 -e1 was tested